### PR TITLE
DEP-6958 correcting hour to uppercase H

### DIFF
--- a/app/connectors/NuanceReportingConnector.scala
+++ b/app/connectors/NuanceReportingConnector.scala
@@ -35,7 +35,7 @@ class NuanceReportingConnector @Inject()(http: HttpClientV2, config: AppConfig)(
 
     implicit val hc: HeaderCarrier = new HeaderCarrier()
 
-    val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")
+    val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
 
     val formattedStartDate = request.startDate.format(dateTimeFormatter)
     val formattedEndDate = request.endDate.format(dateTimeFormatter)

--- a/test/connectors/NuanceReportingConnectorSpec.scala
+++ b/test/connectors/NuanceReportingConnectorSpec.scala
@@ -47,7 +47,7 @@ class NuanceReportingConnectorSpec extends BaseConnectorSpec {
   private val testStartDate = LocalDateTime.now().minusHours(5)
   private val testEndDate = LocalDateTime.now().minusHours(3)
 
-  private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")
+  private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
   private val formattedTestStartDate = dateTimeFormatter.format(testStartDate)
   private val formattedTestEndDate = dateTimeFormatter.format(testEndDate)
 


### PR DESCRIPTION
# DEP-6958

Lowercase h in timeformat is hour in 12hr clock (ie. 0-12). This is causing some overlap when fetching the data from nuance, resulting in duplicate events being retrieved. Correcting it to hour in 24hr clock (0-23). 

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge